### PR TITLE
Return nip.Rule struct from Evaluate function in itemfilter

### DIFF
--- a/cmd/itemwatcher/internal/watcher.go
+++ b/cmd/itemwatcher/internal/watcher.go
@@ -55,7 +55,7 @@ func (w *Watcher) Start(ctx context.Context) error {
 
 			d := w.gr.GetData()
 			for _, i := range d.Items.ByLocation(item.LocationGround) {
-				match, _ := itemfilter.Evaluate(i, w.rules)
+				_, match := itemfilter.Evaluate(i, w.rules)
 				if !match {
 					continue
 				}

--- a/cmd/itemwatcher/internal/watcher.go
+++ b/cmd/itemwatcher/internal/watcher.go
@@ -55,7 +55,8 @@ func (w *Watcher) Start(ctx context.Context) error {
 
 			d := w.gr.GetData()
 			for _, i := range d.Items.ByLocation(item.LocationGround) {
-				if !itemfilter.Evaluate(i, w.rules) {
+				match, _ := itemfilter.Evaluate(i, w.rules)
+				if !match {
 					continue
 				}
 

--- a/pkg/itemfilter/itemfilter.go
+++ b/pkg/itemfilter/itemfilter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/nip"
 )
 
-func Evaluate(i data.Item, rules []nip.Rule) bool {
+func Evaluate(i data.Item, rules []nip.Rule) (bool, nip.Rule) {
 	for _, r := range rules {
 		if !evaluateGroups(i, r.Properties, checkProperty) {
 			// Properties not matching, skipping
@@ -17,15 +17,15 @@ func Evaluate(i data.Item, rules []nip.Rule) bool {
 
 		// We can not check stats, item is not identified, but properties matching
 		if !i.Identified {
-			return true
+			return true, nip.Rule{}
 		}
 
 		if evaluateGroups(i, r.Stats, checkStat) {
-			return true
+			return true, r
 		}
 	}
 
-	return false
+	return false, nip.Rule{}
 }
 
 func evaluateGroups(i data.Item, groups []nip.Group, evalFunc func(i data.Item, prop nip.Comparable) bool) bool {

--- a/pkg/itemfilter/itemfilter.go
+++ b/pkg/itemfilter/itemfilter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/nip"
 )
 
-func Evaluate(i data.Item, rules []nip.Rule) (bool, nip.Rule) {
+func Evaluate(i data.Item, rules []nip.Rule) (nip.Rule, bool) {
 	for _, r := range rules {
 		if !evaluateGroups(i, r.Properties, checkProperty) {
 			// Properties not matching, skipping
@@ -17,15 +17,15 @@ func Evaluate(i data.Item, rules []nip.Rule) (bool, nip.Rule) {
 
 		// We can not check stats, item is not identified, but properties matching
 		if !i.Identified {
-			return true, nip.Rule{}
+			return nip.Rule{}, true
 		}
 
 		if evaluateGroups(i, r.Stats, checkStat) {
-			return true, r
+			return r, true
 		}
 	}
 
-	return false, nip.Rule{}
+	return nip.Rule{}, false
 }
 
 func evaluateGroups(i data.Item, groups []nip.Group, evalFunc func(i data.Item, prop nip.Comparable) bool) bool {

--- a/pkg/itemfilter/itemfilter_test.go
+++ b/pkg/itemfilter/itemfilter_test.go
@@ -37,7 +37,7 @@ func TestEvaluate(t *testing.T) {
 			rule, err := nip.ParseLine(tt.args.nipRule)
 			require.NoError(t, err)
 
-			if got, _ := Evaluate(tt.args.i, []nip.Rule{rule}); got != tt.want {
+			if _, got := Evaluate(tt.args.i, []nip.Rule{rule}); got != tt.want {
 				t.Errorf("Evaluate() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/itemfilter/itemfilter_test.go
+++ b/pkg/itemfilter/itemfilter_test.go
@@ -37,7 +37,7 @@ func TestEvaluate(t *testing.T) {
 			rule, err := nip.ParseLine(tt.args.nipRule)
 			require.NoError(t, err)
 
-			if got := Evaluate(tt.args.i, []nip.Rule{rule}); got != tt.want {
+			if got, _ := Evaluate(tt.args.i, []nip.Rule{rule}); got != tt.want {
 				t.Errorf("Evaluate() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This pull request implements returning the Rule which matches against the item in itemfilter's `Evaluate` function.

This way the consumers of that function can check for the rule properties (e.g. maxquantity) and make further decisions based on that.
