### PR TITLE
Added States for monsters and corpses

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -139,6 +139,7 @@ type Corpse struct {
 	Found     bool
 	IsHovered bool
 	Position  Position
+	States    state.States
 }
 
 type Position struct {
@@ -289,4 +290,24 @@ type OpenMenus struct {
 
 func (om OpenMenus) IsMenuOpen() bool {
 	return om.Inventory || om.NPCInteract || om.NPCShop || om.Stash || om.Waypoint || om.SkillTree || om.Character || om.QuitMenu || om.Cube || om.SkillSelect || om.Anvil
+}
+func (c Corpse) StateNotInteractable() bool {
+	CorpseStates := []state.State{
+		state.CorpseNoselect,
+		state.CorpseNodraw,
+		state.Revive,
+		state.Redeemed,
+		state.Shatter,
+		state.Freeze,
+	}
+
+	for _, s := range c.States {
+		for _, d := range CorpseStates {
+			if s == d {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/pkg/data/npc.go
+++ b/pkg/data/npc.go
@@ -3,6 +3,7 @@ package data
 import (
 	"github.com/hectorgimenez/d2go/pkg/data/npc"
 	"github.com/hectorgimenez/d2go/pkg/data/stat"
+	"github.com/hectorgimenez/d2go/pkg/data/state"
 )
 
 type NPC struct {
@@ -20,6 +21,7 @@ type Monster struct {
 	Position  Position
 	Stats     map[stat.ID]int
 	Type      MonsterType
+	States    state.States
 }
 
 type Monsters []Monster

--- a/pkg/memory/game_reader.go
+++ b/pkg/memory/game_reader.go
@@ -44,6 +44,7 @@ func (gd *GameReader) GetData() data.Data {
 			Found:     corpseUnit.Address != 0,
 			IsHovered: corpseUnit.IsHovered,
 			Position:  corpseUnit.Position,
+			States:    corpseUnit.States,
 		},
 		Game: data.OnlineGame{
 			LastGameName:     gd.LastGameName(),

--- a/pkg/memory/monsters.go
+++ b/pkg/memory/monsters.go
@@ -48,6 +48,7 @@ func (gd *GameReader) Monsters(playerPosition data.Position, hover data.HoverDat
 			statCount := gd.Process.ReadUInt(statsListExPtr+0x38, Uint64)
 
 			stats := gd.getMonsterStats(statCount, statPtr)
+			states := gd.GetStates(statsListExPtr)
 
 			// This excludes good NPCs but includes Mercs
 			if !gd.shouldBeIgnored(txtFileNo) || stats[stat.Experience] > 0 {
@@ -59,8 +60,9 @@ func (gd *GameReader) Monsters(playerPosition data.Position, hover data.HoverDat
 						X: int(posX),
 						Y: int(posY),
 					},
-					Stats: stats,
-					Type:  getMonsterType(flag),
+					Stats:  stats,
+					Type:   getMonsterType(flag),
+					States: states,
 				}
 
 				if isCorpse == 0 {
@@ -146,6 +148,7 @@ func (gd *GameReader) Corpses(playerPosition data.Position, hover data.HoverData
 			statCount := gd.Process.ReadUInt(statsListExPtr+0x38, Uint64)
 
 			stats := gd.getMonsterStats(statCount, statPtr)
+			states := gd.GetStates(statsListExPtr)
 
 			hovered := hover.IsHovered && hover.UnitType == 1 && hover.UnitID == data.UnitID(unitID)
 
@@ -158,8 +161,9 @@ func (gd *GameReader) Corpses(playerPosition data.Position, hover data.HoverData
 						X: int(posX),
 						Y: int(posY),
 					},
-					Stats: stats,
-					Type:  getMonsterType(flag),
+					Stats:  stats,
+					Type:   getMonsterType(flag),
+					States: states,
 				}
 
 				corpses = append(corpses, m)

--- a/pkg/memory/player.go
+++ b/pkg/memory/player.go
@@ -45,7 +45,7 @@ func (gd *GameReader) GetRawPlayerUnits() RawPlayerUnits {
 			statsListExPtr := uintptr(gd.Process.ReadUInt(playerUnit+0x88, Uint64))
 			baseStats := gd.getStatsList(statsListExPtr + 0x30)
 			stats := gd.getStatsList(statsListExPtr + 0x88)
-			states := gd.getStates(statsListExPtr)
+			states := gd.GetStates(statsListExPtr)
 
 			rawPlayerUnits = append(rawPlayerUnits, RawPlayerUnit{
 				UnitID:       data.UnitID(unitID),
@@ -140,8 +140,8 @@ func (gd *GameReader) getSkills(skillListPtr uintptr) map[skill.ID]skill.Points 
 	return skills
 }
 
-func (gd *GameReader) getStates(statsListExPtr uintptr) []state.State {
-	var states []state.State
+func (gd *GameReader) GetStates(statsListExPtr uintptr) state.States {
+	var states state.States
 	for i := 0; i < 6; i++ {
 		offset := i * 4
 		stateByte := gd.Process.ReadUInt(statsListExPtr+0xAD0+uintptr(offset), Uint32)


### PR DESCRIPTION
Now can properly identify if a corpse is interactable with a skill ( barbarian, necromancer)
Also getting states about monsters  : Exemple  Soul Killer with Conviction aura:   State  28 // conviction

Also can tell if monster has a state after you used a skill on it  Exemple:   State 56  Terror ( After using Barbarian skill Howl to fear )

Another Exemple  using Grief on Mephistos he now have  states :    2 poison   -    52  Preventheal

will be very useful for further development.