### PR TITLE
QuestLog added to OpenMenus function for leveling

### DIFF
--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -300,7 +300,7 @@ type OpenMenus struct {
 }
 
 func (om OpenMenus) IsMenuOpen() bool {
-	return om.Inventory || om.NPCInteract || om.NPCShop || om.Stash || om.Waypoint || om.SkillTree || om.Character || om.QuitMenu || om.Cube || om.SkillSelect || om.Anvil
+	return om.Inventory || om.NPCInteract || om.NPCShop || om.Stash || om.Waypoint || om.SkillTree || om.Character || om.QuitMenu || om.Cube || om.SkillSelect || om.Anvil || om.QuestLog
 }
 func (c Corpse) StateNotInteractable() bool {
 	CorpseStates := []state.State{


### PR DESCRIPTION
Quest menu was not closing when leveling. Added 'QuestLog' to the OpenMenus function in d2go. This ensures that the quest menu is included in the check for any open menus, which is used to also close them. 
Tested as working on local version.
My first pull request so apologies if this isn't the correct process. It should be as far as I've read online.