### PR TITLE
Remove [level] example in pickit rules

### DIFF
--- a/cmd/itemwatcher/config/itemfilter/unid.nip
+++ b/cmd/itemwatcher/config/itemfilter/unid.nip
@@ -162,7 +162,3 @@
 //[name] == grandcharm 		&& [quality] == unique										// gheed's fortune
 [name] == largecharm 		&& [quality] == unique 										// hellfire torch
 [name] == smallcharm 		&& [quality] == unique										// annihilus
-
-// magic charms for cubing
-//[name] == grandcharm 		&& [quality] == magic && [level] >= 91
-//[name] == smallcharm 		&& [quality] == magic && [level] >= 91


### PR DESCRIPTION
Since we don't have an item's level in D2R, remove this example from the pickit rules.