### PR TITLE
Linking Item.LevelReq to stat(92) stat.LevelRequire . Update nip parser

### DIFF
--- a/pkg/memory/item.go
+++ b/pkg/memory/item.go
@@ -467,7 +467,15 @@ func (gd *GameReader) Inventory(rawPlayerUnits RawPlayerUnits, hover data.HoverD
 		}
 
 		itm.LevelReq = maxReq
+		// Update stat 92 (LevelRequire)
+		for it, s := range itm.Stats {
+			if s.ID == stat.LevelRequire {
+				itm.Stats[it].Value = maxReq
+				break
+			}
+		}
 		inventory.AllItems[i] = *itm
+
 	}
 
 	// Sort items by distance if needed, using pre-calculated distances
@@ -491,6 +499,15 @@ func (gd *GameReader) getItemStats(statsListExPtr uintptr) (stat.Stats, stat.Sta
 	// Initial full and base stats extraction
 	fullStats := gd.getStatsList(statsListExPtr + 0xA8)
 	baseStats := gd.getStatsList(statsListExPtr + 0x30)
+
+	// Create empty LevelRequire stat .We will update it from inventory
+	if _, found := fullStats.FindStat(stat.LevelRequire, 0); !found {
+		fullStats = append(fullStats, stat.Data{
+			ID:    stat.LevelRequire,
+			Value: 0,
+			Layer: 0,
+		})
+	}
 
 	// Flags and last stat list pointers
 	flags := gd.Process.ReadUInt(statsListExPtr+0x1C, Uint64)

--- a/pkg/nip/rule.go
+++ b/pkg/nip/rule.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	fixedPropsRegexp = regexp.MustCompile(`(\[(type|quality|class|name|flag|color|prefix|suffix|levelreq)]\s*(<=|<|>|>=|!=|==)\s*([a-zA-Z0-9]+))`)
+	fixedPropsRegexp = regexp.MustCompile(`(\[(type|quality|class|name|flag|color|prefix|suffix)]\s*(<=|<|>|>=|!=|==)\s*([a-zA-Z0-9]+))`)
 	statsRegexp      = regexp.MustCompile(`\[(.*?)]`)
 	maxQtyRegexp     = regexp.MustCompile(`(\[maxquantity]\s*(<=|<|>|>=|!=|==)\s*([0-9]+))`)
 )
@@ -169,8 +169,6 @@ func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
 					break
 				}
 			}
-		case "levelreq":
-			stage1Props["levelreq"] = it.LevelReq
 		case "color":
 			// TODO: Not supported yet
 		}
@@ -238,7 +236,7 @@ func replaceStringPropertiesInStage1(stage1 string) (string, error) {
 			replaceWith = strings.ReplaceAll(prop[0], prop[4], fmt.Sprintf("%d", item.GetIDByName(prop[4])))
 		case "flag":
 			replaceWith = strings.ReplaceAll(prop[0], prop[4], fmt.Sprintf("%d", 1))
-		case "prefix", "suffix", "levelreq":
+		case "prefix", "suffix":
 			// Handle prefix/suffix IDs and levelreq
 			replaceWith = strings.ReplaceAll(prop[0], prop[4], prop[4])
 		case "color":


### PR DESCRIPTION
Can use stat.LevelRequire  just like in standard pickits.

Next commit : Update levelreq on  upgraded unique/set items