### PR TITLE
Fix broken negative stats, update some stat description

### DIFF
--- a/pkg/data/stat/stats.go
+++ b/pkg/data/stat/stats.go
@@ -1179,7 +1179,7 @@ var StatStringMap = map[int]map[int]string{
 	157: {0: "Fires Magic Arrows"},              // itemmagicarrow
 	158: {0: "Fires Explosive Arrows or Bolts"}, // itemexplosivearrow
 	159: {0: "# To Minimum Damage"},
-	160: {0: "# Throw Damage"},
+	160: {0: "+# Maximum Damage"},
 	161: {0: "itemskillhandofathena ????"},
 	162: {0: "itemskillstaminapercent ????"},
 	163: {0: "itemskillpassivestaminapercent ????"},

--- a/pkg/data/stat/stats.go
+++ b/pkg/data/stat/stats.go
@@ -839,7 +839,7 @@ var StatStringMap = map[int]map[int]string{
 	64: {0: "stamdrainmindam ????"},
 	65: {0: "stamdrainmaxdam ????"},
 	66: {0: "stunlength ????"},
-	67: {0: "+#% Faster Run/Walk"},
+	67: {0: "#% Velocity"},
 	68: {0: "#"}, // attackrate
 	69: {0: "otheranimrate ????"},
 	70: {0: "Quantity: #"},
@@ -1214,7 +1214,7 @@ var StatStringMap = map[int]map[int]string{
 		8:  "+# to Fire Skills (Sorceress only)",              // fireskilltab
 		9:  "+# to Lightning Skills (Sorceress only)",         // lightningskilltab
 		10: "+# to Cold Skills (Sorceress only)",              // coldskilltab
-		16: "+# to Curses Skills (Sorceress only)",            // cursesskilltab
+		16: "+# to Curses Skills (Necromancer only)",          // cursesskilltab
 		17: "+# to Poison and Bone Skills (Necromancer only)", // poisonandboneskilltab
 		18: "+# to Summoning Skills (Necromancer only)",       // necromancersummoningskilltab
 		24: "+# to Paladin Combat Skills (Paladin only)",      // palicombatskilltab

--- a/pkg/data/stat/stats.go
+++ b/pkg/data/stat/stats.go
@@ -48,7 +48,7 @@ const (
 	StashGold
 	EnhancedDefense
 	EnhancedDamageMax
-	EnhancedDamage
+	EnhancedDamageMin
 	AttackRating
 	ChanceToBlock
 	MinDamage
@@ -412,7 +412,7 @@ var StringStats = []string{
 	"stashgold",
 	"enhanceddefense",
 	"enhanceddamagemax",
-	"enhanceddamage",
+	"enhanceddamagemin",
 	"attackrating",
 	"chancetoblock",
 	"mindamage",
@@ -779,11 +779,11 @@ var StatStringMap = map[int]map[int]string{
 	13: {0: "Experience: #"},
 	14: {0: "Gold: #"},
 	15: {0: "Gold in Bank: #"},
-	16: {0: "+#% Enhanced Defense"},                                   // enhanceddefense
-	17: {0: "+#% Enhanced Maximum Damage (Based on Character Level)"}, // itemmaxdamagepercent
-	18: {0: "+#% Enhanced Damage"},                                    // enhanceddamage
-	19: {0: "+# to Attack Rating"},                                    // tohit
-	20: {0: "#% Increased Chance of Blocking"},                        // toblock
+	16: {0: "+#% Enhanced Defense"},            // enhanceddefense
+	17: {0: "+#% Enhanced Damage (Max)"},       // enhanceddamagemax
+	18: {0: "+#% Enhanced Damage (Min)"},       // enhanceddamagemin
+	19: {0: "+# to Attack Rating"},             // tohit
+	20: {0: "#% Increased Chance of Blocking"}, // toblock
 	21: {
 		0: "#-# Damage",           // mindamage
 		1: "+# to Minimum Damage", // plusmindamage
@@ -845,7 +845,7 @@ var StatStringMap = map[int]map[int]string{
 	70: {0: "Quantity: #"},
 	71: {0: "Value: #"},
 	72: {0: "Durability: # of #"},                      // durability
-	73: {0: "#"},                                       // maxdurability
+	73: {0: "Max Durability"},                          // maxdurability
 	74: {0: "Replenish Life +#"},                       // hpregen
 	75: {0: "Increase Maximum Durability #%"},          //itemmaxdurabilitypercent
 	76: {0: "Increase Maximum Life #%"},                //itemmaxmanapercent
@@ -1178,8 +1178,8 @@ var StatStringMap = map[int]map[int]string{
 	156: {0: "Piercing Attack"},                 // itempierce
 	157: {0: "Fires Magic Arrows"},              // itemmagicarrow
 	158: {0: "Fires Explosive Arrows or Bolts"}, // itemexplosivearrow
-	159: {0: "itemthrowmindamage ????"},
-	160: {0: "itemthrowmaxdamage ????"},
+	159: {0: "To Minimum Damage"},
+	160: {0: "Throw Damage"},
 	161: {0: "itemskillhandofathena ????"},
 	162: {0: "itemskillstaminapercent ????"},
 	163: {0: "itemskillpassivestaminapercent ????"},
@@ -1237,8 +1237,9 @@ var StatStringMap = map[int]map[int]string{
 	193: {0: "Monster Magic Immunity is Sundered"},     // itempiercemagicimmunity
 	194: {0: "Socketed (#)"},
 	195: {
-		1: "#% Chance to cast level # [Skill] on attack", //itemskillonattack
-		2: "itemskillonattacklevel ????",
+		1:    "#% Chance to cast level # [Skill] on attack", //itemskillonattack
+		2:    "itemskillonattacklevel ????",
+		3395: "#% Chance to cast level 3 Chain Lightning on attack",
 	},
 	196: {
 		1: "#% Chance to cast level # [Skill] when you Kill an Enemy", //itemskillonkill
@@ -1259,15 +1260,18 @@ var StatStringMap = map[int]map[int]string{
 	},
 	200: {0: "unused200 ????"},
 	201: {
-		1: "#% Chance to cast level # [Skill] when struck", //itemskillongethit
-		2: "itemskillongethitlevel ????",
+		1:    "#% Chance to cast level # [Skill] when struck", //itemskillongethit
+		2:    "itemskillongethitlevel ????",
+		5903: "#% Chance to cast level 15 Poison Nova when struck",
+		7751: "#% Chance to cast level 7 Fist of Heavens when struck",
 	},
 	202: {0: "unused202 ????"},
 	203: {0: "unused203 ????"},
 	204: {
-		1:    "itemchargedskill ????",
-		2:    "itemchargedskilllevel ????",
-		3461: "Teleport (charged)",
+		1:     "itemchargedskill ????",
+		2:     "itemchargedskilllevel ????",
+		3461:  "Teleport (charged)",
+		17795: "Venom level 3 (charged)",
 	},
 	205: {0: "unused204 ????"},
 	206: {0: "unused205 ????"},

--- a/pkg/data/stat/stats.go
+++ b/pkg/data/stat/stats.go
@@ -48,7 +48,7 @@ const (
 	StashGold
 	EnhancedDefense
 	EnhancedDamageMin
-	EEnhancedDamage
+	EnhancedDamage
 	AttackRating
 	ChanceToBlock
 	MinDamage

--- a/pkg/data/stat/stats.go
+++ b/pkg/data/stat/stats.go
@@ -47,8 +47,8 @@ const (
 	Gold
 	StashGold
 	EnhancedDefense
-	EnhancedDamageMax
 	EnhancedDamageMin
+	EEnhancedDamage
 	AttackRating
 	ChanceToBlock
 	MinDamage
@@ -411,8 +411,8 @@ var StringStats = []string{
 	"gold",
 	"stashgold",
 	"enhanceddefense",
-	"enhanceddamagemax",
 	"enhanceddamagemin",
+	"enhanceddamage",
 	"attackrating",
 	"chancetoblock",
 	"mindamage",
@@ -845,7 +845,7 @@ var StatStringMap = map[int]map[int]string{
 	70: {0: "Quantity: #"},
 	71: {0: "Value: #"},
 	72: {0: "Durability: # of #"},                      // durability
-	73: {0: "Max Durability"},                          // maxdurability
+	73: {0: "# Max Durability"},                        // maxdurability
 	74: {0: "Replenish Life +#"},                       // hpregen
 	75: {0: "Increase Maximum Durability #%"},          //itemmaxdurabilitypercent
 	76: {0: "Increase Maximum Life #%"},                //itemmaxmanapercent
@@ -1178,8 +1178,8 @@ var StatStringMap = map[int]map[int]string{
 	156: {0: "Piercing Attack"},                 // itempierce
 	157: {0: "Fires Magic Arrows"},              // itemmagicarrow
 	158: {0: "Fires Explosive Arrows or Bolts"}, // itemexplosivearrow
-	159: {0: "To Minimum Damage"},
-	160: {0: "Throw Damage"},
+	159: {0: "# To Minimum Damage"},
+	160: {0: "# Throw Damage"},
 	161: {0: "itemskillhandofathena ????"},
 	162: {0: "itemskillstaminapercent ????"},
 	163: {0: "itemskillpassivestaminapercent ????"},

--- a/pkg/memory/game_reader.go
+++ b/pkg/memory/game_reader.go
@@ -141,14 +141,16 @@ func (gd *GameReader) getStatsList(statListPtr uintptr) stat.Stats {
 	}
 
 	var stats = make([]stat.Data, 0)
+
 	statBuffer := gd.Process.ReadBytesFromMemory(uintptr(statList), statCount*10)
 	for i := 0; i < int(statCount); i++ {
 		offset := uint(i * 8)
+
 		statLayer := ReadUIntFromBuffer(statBuffer, offset, Uint16)
 		statEnum := ReadUIntFromBuffer(statBuffer, offset+0x2, Uint16)
-		statValue := ReadUIntFromBuffer(statBuffer, offset+0x4, Uint32)
+		statValue := ReadIntFromBuffer(statBuffer, offset+0x4, Uint32)
 
-		value := int(statValue)
+		value := statValue
 		switch stat.ID(statEnum) {
 		case stat.Life,
 			stat.MaxLife,
@@ -156,16 +158,16 @@ func (gd *GameReader) getStatsList(statListPtr uintptr) stat.Stats {
 			stat.MaxMana,
 			stat.Stamina,
 			stat.MaxStamina:
-			value = int(statValue >> 8)
+			value = statValue >> 8
 		case stat.ColdLength,
 			stat.PoisonLength:
-			value = int(statValue / 25)
+			value = statValue / 25
 		case stat.DeadlyStrikePerLevel:
 			value = int(float64(statValue) / .8)
 		case stat.HitCausesMonsterToFlee:
 			value = int(float64(statValue) / 1.28)
 		case stat.AttackRatingUndeadPerLevel:
-			value = int(statValue / 2)
+			value = statValue / 2
 		case stat.MagicFindPerLevel,
 			stat.ExtraGoldPerLevel,
 			stat.DamageDemonPerLevel,

--- a/pkg/memory/item.go
+++ b/pkg/memory/item.go
@@ -233,7 +233,7 @@ func (gd *GameReader) Inventory(rawPlayerUnits RawPlayerUnits, hover data.HoverD
 					if len(prefixParts) > 0 {
 						nameParts = append(nameParts, prefixParts...)
 					}
-					nameParts = append(nameParts, string(itm.Name))
+					nameParts = append(nameParts, itm.Desc().Name)
 					if len(suffixParts) > 0 {
 						nameParts = append(nameParts, suffixParts...)
 					}

--- a/pkg/memory/process.go
+++ b/pkg/memory/process.go
@@ -20,6 +20,13 @@ type Process struct {
 	moduleBaseSize       uint32
 }
 
+const (
+	Int8  = 1 // signed 8-bit integer
+	Int16 = 2 // signed 16-bit integer
+	Int32 = 4 // signed 32-bit integer
+	Int64 = 8 // signed 64-bit integer
+)
+
 func NewProcess() (Process, error) {
 	module, err := getGameModule()
 	if err != nil {
@@ -142,6 +149,22 @@ func bytesToUint(bytes []byte, size IntType) uint {
 		return uint(binary.LittleEndian.Uint64(bytes))
 	}
 
+	return 0
+}
+func ReadIntFromBuffer(bytes []byte, offset uint, size IntType) int {
+	return bytesToInt(bytes[offset:offset+uint(size)], size)
+}
+func bytesToInt(bytes []byte, size IntType) int {
+	switch size {
+	case Int8:
+		return int(int8(bytes[0]))
+	case Int16:
+		return int(int16(binary.LittleEndian.Uint16(bytes)))
+	case Int32:
+		return int(int32(binary.LittleEndian.Uint32(bytes)))
+	case Int64:
+		return int(int64(binary.LittleEndian.Uint64(bytes)))
+	}
 	return 0
 }
 

--- a/pkg/nip/rule.go
+++ b/pkg/nip/rule.go
@@ -226,6 +226,13 @@ func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
 
 			itemStat, found := it.FindStat(stat.ID(statData[0]), layer)
 			if found {
+				// Special handling for ItemLevelReq
+				if statData[0] == int(stat.LevelRequire) {
+					// If the rule is looking for ItemLevelReq and the value is 0, reject the item
+					if itemStat.Value == 0 {
+						return RuleResultNoMatch, nil
+					}
+				}
 				stage2Props[statName] = itemStat.Value
 			} else if isResistSum && hasAnyResist {
 				// Only default to 0 for resist sums if we found at least one resist

--- a/pkg/nip/rule.go
+++ b/pkg/nip/rule.go
@@ -136,6 +136,7 @@ func NewRule(rawRule string, filename string, lineNumber int) (Rule, error) {
 }
 
 func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
+	// Stage 1: Basic properties evaluation
 	stage1Props := make(map[string]int)
 	for prop := range fixedPropsList {
 		switch prop {
@@ -173,7 +174,6 @@ func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
 			// TODO: Not supported yet
 		}
 	}
-
 	// Let's evaluate first stage
 	stage1Result, err := expr.Run(r.stage1, stage1Props)
 	if err != nil {
@@ -185,9 +185,34 @@ func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
 		return RuleResultNoMatch, nil
 	}
 
-	stage2Result := true
+	// For stats evaluation
 	if r.stage2 != nil {
 		stage2Props := make(map[string]int)
+
+		// We only want to default to 0 if we find at least one of the required resists
+		hasAnyResist := false
+		stage2 := strings.ToLower(strings.Split(r.RawLine, "#")[1])
+		isResistSum := strings.Contains(stage2, "resist") && (strings.Contains(stage2, "+") || strings.Contains(stage2, "-"))
+
+		// First pass - check if we have any of the required resists
+		if isResistSum {
+			for _, statName := range r.requiredStats {
+				statData, found := statAliases[statName]
+				if !found {
+					continue
+				}
+				layer := 0
+				if len(statData) > 1 {
+					layer = statData[1]
+				}
+				if _, found := it.FindStat(stat.ID(statData[0]), layer); found {
+					hasAnyResist = true
+					break
+				}
+			}
+		}
+
+		// Second pass - evaluate stats
 		for _, statName := range r.requiredStats {
 			statData, found := statAliases[statName]
 			if !found {
@@ -199,48 +224,28 @@ func (r Rule) Evaluate(it data.Item) (RuleResult, error) {
 				layer = statData[1]
 			}
 
-			// If item is unidentified and we have stat requirements, require identification
-			if !it.Identified {
-				return RuleResultPartial, nil
-			}
-
-			// Check if the stat exists on the item
-			itemStat, statFound := it.FindStat(stat.ID(statData[0]), layer)
-
-			// For compound expressions (containing + or -), treat missing stats as 0
-			// Otherwise for single stat checks, require the stat to exist
-			parts := strings.Split(r.RawLine, "#")
-			if len(parts) > 1 && (strings.Contains(parts[1], "+") || strings.Contains(parts[1], "-")) {
-				if !statFound {
-					stage2Props[statName] = 0
-				} else {
-					stage2Props[statName] = itemStat.Value
-				}
-			} else {
-				if !statFound {
-					return RuleResultNoMatch, nil
-				}
+			itemStat, found := it.FindStat(stat.ID(statData[0]), layer)
+			if found {
 				stage2Props[statName] = itemStat.Value
+			} else if isResistSum && hasAnyResist {
+				// Only default to 0 for resist sums if we found at least one resist
+				stage2Props[statName] = 0
+			} else {
+				return RuleResultNoMatch, nil
 			}
 		}
 
-		res, err := expr.Run(r.stage2, stage2Props)
+		stage2Result, err := expr.Run(r.stage2, stage2Props)
 		if err != nil {
 			return RuleResultNoMatch, fmt.Errorf("error evaluating rule: %w", err)
 		}
-		stage2Result = res.(bool)
-	}
 
+		if !stage2Result.(bool) {
+			return RuleResultNoMatch, nil
+		}
+	}
 	// 100% rule match, we can return here
-	if stage1Result.(bool) && stage2Result {
-		return RuleResultFullMatch, nil
-	}
-
-	// If Stage 1 matches and the item is NOT identified, let's return a partial match, we can not be 100% sure if all the stats are matching
-	if stage1Result.(bool) && !it.Identified {
-		return RuleResultPartial, nil
-	}
-	return RuleResultNoMatch, nil
+	return RuleResultFullMatch, nil
 }
 
 func replaceStringPropertiesInStage1(stage1 string) (string, error) {


### PR DESCRIPTION
- **Update** to broken rules :

[name] == grandcharm && [quality] == unique # ([fireresist] + [coldresist] + [lightresist]) >= -75

Single stat rules like [coldresist] >= -75 require the stat to exist

expressions like ([fireresist] + [coldresist] + [lightresist]) >= -75 treat missing stats as 0

**Edit:** if  all  ([fireresist] + [coldresist] + [lightresist])  are nill, dont set to 0 .                      0 + 0 +0  >-75

Unidentified items with any stat requirements need identification first ( after the # )

- **Added** LevelReq  and identifiedName for all **Crafted** items