### PR TITLE
Terror Zone - Dont keep previous tz areas mapped

### DIFF
--- a/pkg/memory/terrorzones.go
+++ b/pkg/memory/terrorzones.go
@@ -5,18 +5,22 @@ import (
 )
 
 func (gd *GameReader) TerrorZones() []area.ID {
+	if gd == nil || gd.moduleBaseAddressPtr == 0 {
+		return []area.ID{} // Return empty slice, not nil
+	}
+
 	tz := gd.moduleBaseAddressPtr + tzOnline
 
-	// Initialize an empty slice to hold only current terror zones -- Flush it to not keep previous when it changes
-	areas := make([]area.ID, 0, 8)
+	// Use a temporary slice to collect current zones
+	var currentZones []area.ID
 
 	for i := 0; i < 8; i++ {
 		tzArea := gd.ReadUInt(tz+uintptr(i*Uint32), Uint32)
 		if tzArea != 0 {
-			areas = append(areas, area.ID(tzArea))
+			currentZones = append(currentZones, area.ID(tzArea))
 		}
 	}
 
-	return areas
+	return currentZones
 }
 

--- a/pkg/memory/terrorzones.go
+++ b/pkg/memory/terrorzones.go
@@ -4,8 +4,11 @@ import (
 	"github.com/hectorgimenez/d2go/pkg/data/area"
 )
 
-func (gd *GameReader) TerrorZones() (areas []area.ID) {
+func (gd *GameReader) TerrorZones() []area.ID {
 	tz := gd.moduleBaseAddressPtr + tzOnline
+
+	// Initialize an empty slice to hold only current terror zones -- Flush it to not keep previous when it changes
+	areas := make([]area.ID, 0, 8)
 
 	for i := 0; i < 8; i++ {
 		tzArea := gd.ReadUInt(tz+uintptr(i*Uint32), Uint32)
@@ -14,5 +17,6 @@ func (gd *GameReader) TerrorZones() (areas []area.ID) {
 		}
 	}
 
-	return
+	return areas
 }
+


### PR DESCRIPTION
Dont append previous Terror zones  when it changes.. This is why we had weird behaviour

Exemple  :
Current tz :  id 5 dark wood    ,  id 14 Underground Passage Level 2  

change to tz :  id 2  Blood Moor,  id 8 Den of Evil

will become :  2,8,14    due to appending existing data.  

We need to flush it.